### PR TITLE
[WIP] Set Startup projects LINQPad script

### DIFF
--- a/SetStartupProjects.linq
+++ b/SetStartupProjects.linq
@@ -6,8 +6,7 @@
 void Main()
 {
 	var currentDiretory = Path.GetDirectoryName(Util.CurrentQueryPath);
-	var exercises = Path.Combine(currentDiretory, "exercises");
-	SetStartupProjects(exercises);
+	SetStartupProjects(currentDiretory);
 }
 
 public static void SetStartupProjects(string codeDirectory)

--- a/SetStartupProjects.linq
+++ b/SetStartupProjects.linq
@@ -1,0 +1,58 @@
+<Query Kind="Program">
+  <NuGetReference>SetStartupProjects</NuGetReference>
+  <Namespace>SetStartupProjects</Namespace>
+</Query>
+
+void Main()
+{
+	var currentDiretory = Path.GetDirectoryName(Util.CurrentQueryPath);
+	var exercises = Path.Combine(currentDiretory, "exercises");
+	SetStartupProjects(exercises);
+}
+
+public static void SetStartupProjects(string codeDirectory)
+{
+	foreach (var suo in Directory.EnumerateDirectories(codeDirectory, ".vs", SearchOption.AllDirectories))
+	{
+		Directory.Delete(suo, true);
+	}
+	foreach (var suo in Directory.EnumerateFiles(codeDirectory, "*.suo", SearchOption.AllDirectories))
+	{
+		File.Delete(suo);
+	}
+	var startProjectSuoCreator = new StartProjectSuoCreator();
+	foreach (var solutionFile in Directory.EnumerateFiles(codeDirectory, "*.sln", SearchOption.AllDirectories))
+	{
+		var startProjects = GetStartupProjects(solutionFile).ToList();
+		if (startProjects.Any())
+		{
+			startProjectSuoCreator.CreateForSolutionFile(solutionFile, startProjects, VisualStudioVersions.Vs2017);
+		}
+	}
+}
+
+public static IEnumerable<string> GetStartupProjects(string solutionFile)
+{
+	var solutionDirectory = Path.Combine(Path.GetDirectoryName(solutionFile));
+	var defaultProjectsTextFile = Path.Combine(solutionDirectory, "DefaultStartupProjects.txt");
+	if (!File.Exists(defaultProjectsTextFile))
+	{
+		var startProjectFinder = new StartProjectFinder();
+		foreach (var startProject in startProjectFinder.GetStartProjects(solutionFile))
+		{
+			yield return startProject;
+		}
+		yield break;
+	}
+	var allPossibleProjects = SolutionProjectExtractor.GetAllProjectFiles(solutionFile).ToList();
+	var defaultProjects = File.ReadAllLines(defaultProjectsTextFile)
+		.Where(x => !string.IsNullOrWhiteSpace(x));
+	foreach (var startupProject in defaultProjects)
+	{
+		var project = allPossibleProjects.FirstOrDefault(x => x.RelativePath == startupProject);
+		if (project != null)
+		{
+			yield return project.Guid;
+		}
+	}
+}

--- a/exercises/01-composite-ui/before/01-composite-ui-before.StartupProjects.txt
+++ b/exercises/01-composite-ui/before/01-composite-ui-before.StartupProjects.txt
@@ -1,4 +1,0 @@
-Divergent.Customers.API\Divergent.Customers.API.csproj
-Divergent.Finance.API\Divergent.Finance.API.csproj
-Divergent.Frontend\Divergent.Frontend.csproj
-Divergent.Sales.API\Divergent.Sales.API.csproj

--- a/exercises/01-composite-ui/before/01-composite-ui-before.StartupProjects.txt
+++ b/exercises/01-composite-ui/before/01-composite-ui-before.StartupProjects.txt
@@ -1,10 +1,4 @@
-Divergent.Customers.API
-\Divergent.Customers.API
-.csproj
-Divergent.Finance.API
-\Divergent.Finance.API
-.csproj
-Divergent.Frontend
-\Divergent.Frontend
-.csproj
+Divergent.Customers.API\Divergent.Customers.API.csproj
+Divergent.Finance.API\Divergent.Finance.API.csproj
+Divergent.Frontend\Divergent.Frontend.csproj
 Divergent.Sales.API\Divergent.Sales.API.csproj

--- a/exercises/01-composite-ui/before/01-composite-ui-before.StartupProjects.txt
+++ b/exercises/01-composite-ui/before/01-composite-ui-before.StartupProjects.txt
@@ -1,0 +1,10 @@
+Divergent.Customers.API
+\Divergent.Customers.API
+.csproj
+Divergent.Finance.API
+\Divergent.Finance.API
+.csproj
+Divergent.Frontend
+\Divergent.Frontend
+.csproj
+Divergent.Sales.API\Divergent.Sales.API.csproj


### PR DESCRIPTION
This is a very handy way to setup startup projects in one go for all the exercises. This spike requires LINQPad, but the script can be easily converted into an executable that attendees can run on their machine once they download or clone this repo.

The `01-composite-ui-before.StartupProjects.txt` si not needed, it is in this PR just to show how it can be used to customize startup projects if needed. The `SetStartupProjects` is clever enough to detect automatically which projects should be startup projects. It works very well on all exercises.