### PR TITLE
add set-startup-projects.cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,17 @@ The exercises are contained in eight Visual Studio solutions under [exercises](e
 
 ## Running the exercise solutions
 
-- Before you run a given exercise solution, configure the startup projects listed in the instructions for that exercise:
+Before opening any exercise solutions, set the startup projects by navigating to your copy of this repo and running `set-startup-projects.cmd`. Note that if you `git clean` your clone, you will have to run this command again.
+
+The startup projects are also listed in the instructions for each exercise. If you need to, you can configure them manually:
+
   - In Visual Studio, right click the solution in the Solution Explorer
   - Click "Properties"
   - Ensure that, in the left hand pane, "Common Properties", "Start Project" is selected.
   - Select the "Multiple startup projects" radio button
   - Set the "Action" for each project listed in the instructions for the exercise to "Start".
-- Press <kbd>F5</kbd> in Visual Studio. The exercise solution will now be running and be fully functional.
+
+To run an exercise solution, simply press <kbd>F5</kbd> in Visual Studio. The exercise solution will now be running and fully functional.
 
 ### Note
 

--- a/build.csx
+++ b/build.csx
@@ -1,8 +1,11 @@
+#r "packages/SetStartupProjects.1.4.0/lib/net452/SetStartupProjects.dll"
+
 #load "packages/simple-targets-csx.6.0.0/contentFiles/csx/any/simple-targets.csx"
 #load "scripts/cmd.csx"
 
 using System;
 using static SimpleTargets;
+using SetStartupProjects;
 
 var vswhere = "packages/vswhere.2.1.4/tools/vswhere.exe";
 var nuget = ".nuget/v4.3.0/NuGet.exe";
@@ -60,5 +63,33 @@ targets.Add(
             Cmd(msBuild, $"{solution} /p:Configuration=Debug /nologo /m /v:m /nr:false");
         }
     });
+
+targets.Add(
+    "delete-vs-folders",
+    () =>
+    {
+        foreach (var suo in Directory.EnumerateDirectories(".", ".vs", SearchOption.AllDirectories))
+        {
+            Directory.Delete(suo, true);
+        }
+    }
+);
+
+targets.Add(
+    "set-startup-projects",
+    DependsOn("delete-vs-folders"),
+    () =>
+    {
+        var suoCreator = new StartProjectSuoCreator();
+        foreach (var sln in Directory.EnumerateFiles(".", "*.sln", SearchOption.AllDirectories))
+        {
+            var startProjects = new StartProjectFinder().GetStartProjects(sln).ToList();
+            if (startProjects.Any())
+            {
+                suoCreator.CreateForSolutionFile(sln, startProjects, VisualStudioVersions.Vs2017);
+            }
+        }
+    }
+);
 
 Run(Args, targets);

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Net.Compilers" version="2.4.0" />
+  <package id="SetStartupProjects" version="1.4.0" />
   <package id="simple-targets-csx" version="6.0.0" />
   <package id="vswhere" version="2.1.4" />
 </packages>

--- a/set-startup-projects.cmd
+++ b/set-startup-projects.cmd
@@ -1,0 +1,1 @@
+build.cmd set-startup-projects


### PR DESCRIPTION
This is an alternative approach to https://github.com/Particular/Workshop/pull/135

Although we talked about using `dotnet run` against a regular .NET project, I thought it's best to just add a target to build.csx for now. We can consider moving away from a script as a separate concern.