### PR TITLE
corrected comment wording in the context of the exercises

### DIFF
--- a/exercises/01-composite-ui/README.md
+++ b/exercises/01-composite-ui/README.md
@@ -88,8 +88,7 @@ namespace Divergent.Finance.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -101,7 +100,7 @@ namespace Divergent.Finance.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20187/api/prices/orders/total?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/01-composite-ui/after/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/01-composite-ui/after/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Customers.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Customers.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20186/api/customers/byorders?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/01-composite-ui/after/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/01-composite-ui/after/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Finance.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Finance.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20187/api/prices/orders/total?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/01-composite-ui/before/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/01-composite-ui/before/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Customers.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Customers.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20186/api/customers/byorders?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/02-publish-subscribe/after/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/02-publish-subscribe/after/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Customers.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Customers.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20186/api/customers/byorders?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/02-publish-subscribe/after/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/02-publish-subscribe/after/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Finance.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Finance.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20187/api/prices/orders/total?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/02-publish-subscribe/before/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/02-publish-subscribe/before/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Customers.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Customers.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20186/api/customers/byorders?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/02-publish-subscribe/before/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/02-publish-subscribe/before/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Finance.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Finance.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20187/api/prices/orders/total?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/03-sagas/after/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/03-sagas/after/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Customers.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
             && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Customers.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20186/api/customers/byorders?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/03-sagas/after/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/03-sagas/after/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Finance.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
             && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Finance.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20187/api/prices/orders/total?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/03-sagas/before/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/03-sagas/before/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Customers.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
             && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Customers.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20186/api/customers/byorders?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/03-sagas/before/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/03-sagas/before/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Finance.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
             && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Finance.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20187/api/prices/orders/total?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/04-integration/after/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/04-integration/after/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Customers.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Customers.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20186/api/customers/byorders?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/04-integration/after/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/04-integration/after/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Finance.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Finance.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20187/api/prices/orders/total?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/04-integration/before/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/04-integration/before/Divergent.Customers.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Customers.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Customers.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20186/api/customers/byorders?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/04-integration/before/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
+++ b/exercises/04-integration/before/Divergent.Finance.ViewModelComposition/OrdersLoadedSubscriber.cs
@@ -10,8 +10,7 @@ namespace Divergent.Finance.ViewModelComposition
 {
     public class OrdersLoadedSubscriber : ISubscribeToCompositionEvents
     {
-        // Matching is a bit weak in this demo.
-        // It's written this way to satisfy both the composite gateway and website demos.
+        // Very simple matching for the purpose of the exercise.
         public bool Matches(RouteData routeData, string httpMethod) =>
             HttpMethods.IsGet(httpMethod)
                 && string.Equals((string)routeData.Values["controller"], "orders", StringComparison.OrdinalIgnoreCase)
@@ -23,7 +22,7 @@ namespace Divergent.Finance.ViewModelComposition
             {
                 var orderIds = string.Join(",", ordersLoaded.OrderViewModelDictionary.Keys);
 
-                // Hardcoded to simplify the demo. In a production app, a config object could be injected.
+                // Hardcoded to simplify the exercise. In a production app, a config object could be injected.
                 var url = $"http://localhost:20187/api/prices/orders/total?orderIds={orderIds}";
                 var response = await new HttpClient().GetAsync(url);
 

--- a/exercises/shared-api-gateway/ITOps.ViewModelComposition.Gateway/ComposableRouteHandler.cs
+++ b/exercises/shared-api-gateway/ITOps.ViewModelComposition.Gateway/ComposableRouteHandler.cs
@@ -13,7 +13,7 @@ namespace ITOps.ViewModelComposition.Gateway
 
             if (result.StatusCode == StatusCodes.Status200OK)
             {
-                // For the purposes of the demo, we're not respecting the HTTP Accept header and assuming that a JSON response is OK.
+                // For the purposes of the exercise, we're not respecting the HTTP Accept header and assuming that a JSON response is OK.
                 context.Response.ContentType = "application/json; charset=utf-8";
                 string json = JsonConvert.SerializeObject(result.ViewModel, GetSettings(context));
                 await context.Response.WriteAsync(json);


### PR DESCRIPTION
The current wording is a hangover from copy-pasting the gateway code from the demo.