### PR TITLE
refactor API controllers

### DIFF
--- a/exercises/01-composite-ui/README.md
+++ b/exercises/01-composite-ui/README.md
@@ -38,7 +38,7 @@ In this exercise we'll display the count of items in an order by retrieving it f
 Add an `ItemsCount` property to the anonymous object returned by `OrdersController.Get()` (`Divergent.Sales.API\Controllers\OrdersController.cs`):
 
 ```c#
-ItemsCount = o.Items.Count
+ItemsCount = order.Items.Count
 ```
 
 ### Step 2

--- a/exercises/01-composite-ui/after/Divergent.Finance.API/Controllers/PricesController.cs
+++ b/exercises/01-composite-ui/after/Divergent.Finance.API/Controllers/PricesController.cs
@@ -1,5 +1,4 @@
 ﻿using Divergent.Finance.Data.Context;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
@@ -12,23 +11,21 @@ namespace Divergent.Finance.API.Controllers
         [HttpGet, Route("orders/total")]
         public IEnumerable<dynamic> GetOrdersTotal(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
             using (var db = new FinanceContext())
             {
-                var query = db.OrderItemPrices
-                    .Where(op => _orderIds.Contains(op.OrderId))
-                    .GroupBy(op => op.OrderId)
-                    .Select(g => new
+                return db.OrderItemPrices
+                    .Where(orderItemPrice => orderIdList.Contains(orderItemPrice.OrderId))
+                    .GroupBy(orderItemPrice => orderItemPrice.OrderId)
+                    .Select(orderGroup => new
                     {
-                        OrderId = g.Key,
-                        Amount = g.Sum(op => op.ItemPrice)
-                    });
-
-                var result = query.ToArray();
-                return result;
+                        OrderId = orderGroup.Key,
+                        Amount = orderGroup.Sum(orderItemPrice => orderItemPrice.ItemPrice),
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/01-composite-ui/after/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/01-composite-ui/after/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -12,21 +12,19 @@ namespace Divergent.Sales.API.Controllers
         [HttpGet]
         public IEnumerable<dynamic> Get()
         {
-            using (var _context = new SalesContext())
+            using (var db = new SalesContext())
             {
-                var orders = _context.Orders
-                    .Include(i => i.Items)
-                    .Include(i => i.Items.Select(x => x.Product))
-                    .ToArray();
-
-                return orders
-                    .Select(o => new
+                return db.Orders
+                    .Include(order => order.Items)
+                    .Include(order => order.Items.Select(item => item.Product))
+                    .Select(order => new
                     {
-                        o.Id,
-                        o.CustomerId,
-                        ProductIds = o.Items.Select(i => i.Product.Id),
-                        ItemsCount = o.Items.Count
-                    });
+                        order.Id,
+                        order.CustomerId,
+                        ProductIds = order.Items.Select(item => item.Product.Id).ToList(),
+                        ItemsCount = order.Items.Count,
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/01-composite-ui/before/Divergent.Finance.API/Controllers/PricesController.cs
+++ b/exercises/01-composite-ui/before/Divergent.Finance.API/Controllers/PricesController.cs
@@ -1,5 +1,4 @@
 ﻿using Divergent.Finance.Data.Context;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
@@ -12,23 +11,21 @@ namespace Divergent.Finance.API.Controllers
         [HttpGet, Route("orders/total")]
         public IEnumerable<dynamic> GetOrdersTotal(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
             using (var db = new FinanceContext())
             {
-                var query = db.OrderItemPrices
-                    .Where(op => _orderIds.Contains(op.OrderId))
-                    .GroupBy(op => op.OrderId)
-                    .Select(g => new
+                return db.OrderItemPrices
+                    .Where(orderItemPrice => orderIdList.Contains(orderItemPrice.OrderId))
+                    .GroupBy(orderItemPrice => orderItemPrice.OrderId)
+                    .Select(orderGroup => new
                     {
-                        OrderId = g.Key,
-                        Amount = g.Sum(op => op.ItemPrice)
-                    });
-
-                var result = query.ToArray();
-                return result;
+                        OrderId = orderGroup.Key,
+                        Amount = orderGroup.Sum(orderItemPrice => orderItemPrice.ItemPrice),
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/01-composite-ui/before/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/01-composite-ui/before/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -12,20 +12,18 @@ namespace Divergent.Sales.API.Controllers
         [HttpGet]
         public IEnumerable<dynamic> Get()
         {
-            using (var _context = new SalesContext())
+            using (var db = new SalesContext())
             {
-                var orders = _context.Orders
-                    .Include(i => i.Items)
-                    .Include(i => i.Items.Select(x => x.Product))
-                    .ToArray();
-
-                return orders
-                    .Select(o => new
+                return db.Orders
+                    .Include(order => order.Items)
+                    .Include(order => order.Items.Select(item => item.Product))
+                    .Select(order => new
                     {
-                        o.Id,
-                        o.CustomerId,
-                        ProductIds = o.Items.Select(i => i.Product.Id),
-                    });
+                        order.Id,
+                        order.CustomerId,
+                        ProductIds = order.Items.Select(item => item.Product.Id).ToList(),
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/02-publish-subscribe/after/Divergent.Finance.API/Controllers/PricesController.cs
+++ b/exercises/02-publish-subscribe/after/Divergent.Finance.API/Controllers/PricesController.cs
@@ -1,5 +1,4 @@
 ﻿using Divergent.Finance.Data.Context;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
@@ -12,23 +11,21 @@ namespace Divergent.Finance.API.Controllers
         [HttpGet, Route("orders/total")]
         public IEnumerable<dynamic> GetOrdersTotal(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
             using (var db = new FinanceContext())
             {
-                var query = db.OrderItemPrices
-                    .Where(op => _orderIds.Contains(op.OrderId))
-                    .GroupBy(op => op.OrderId)
-                    .Select(g => new
+                return db.OrderItemPrices
+                    .Where(orderItemPrice => orderIdList.Contains(orderItemPrice.OrderId))
+                    .GroupBy(orderItemPrice => orderItemPrice.OrderId)
+                    .Select(orderGroup => new
                     {
-                        OrderId = g.Key,
-                        Amount = g.Sum(op => op.ItemPrice)
-                    });
-
-                var result = query.ToArray();
-                return result;
+                        OrderId = orderGroup.Key,
+                        Amount = orderGroup.Sum(orderItemPrice => orderItemPrice.ItemPrice),
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/02-publish-subscribe/after/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/02-publish-subscribe/after/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using Divergent.Sales.Data.Context;
+using Divergent.Sales.Messages.Commands;
+using NServiceBus;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Http;
-using Divergent.Sales.Data.Context;
-using NServiceBus;
-using Divergent.Sales.Messages.Commands;
 
 namespace Divergent.Sales.API.Controllers
 {
@@ -14,17 +14,14 @@ namespace Divergent.Sales.API.Controllers
     {
         private readonly IEndpointInstance _endpoint;
 
-        public OrdersController(IEndpointInstance endpoint)
-        {
-            _endpoint = endpoint;
-        }
+        public OrdersController(IEndpointInstance endpoint) => _endpoint = endpoint;
 
         [HttpPost, Route("createOrder")]
         public async Task<dynamic> CreateOrder(dynamic payload)
         {
             var customerId = int.Parse((string)payload.customerId);
             var productIds = ((IEnumerable<dynamic>)payload.products)
-                .Select(p => int.Parse((string)p.productId))
+                .Select(product => int.Parse((string)product.productId))
                 .ToList();
 
             await _endpoint.Send(new SubmitOrderCommand
@@ -39,21 +36,19 @@ namespace Divergent.Sales.API.Controllers
         [HttpGet]
         public IEnumerable<dynamic> Get()
         {
-            using (var _context = new SalesContext())
+            using (var db = new SalesContext())
             {
-                var orders = _context.Orders
-                .Include(i => i.Items)
-                .Include(i => i.Items.Select(x => x.Product))
-                .ToArray();
-
-                return orders
-                    .Select(o => new
+                return db.Orders
+                    .Include(order => order.Items)
+                    .Include(order => order.Items.Select(item => item.Product))
+                    .Select(order => new
                     {
-                        o.Id,
-                        o.CustomerId,
-                        ProductIds = o.Items.Select(i => i.Product.Id),
-                        ItemsCount = o.Items.Count
-                    });
+                        order.Id,
+                        order.CustomerId,
+                        ProductIds = order.Items.Select(item => item.Product.Id).ToList(),
+                        ItemsCount = order.Items.Count
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/02-publish-subscribe/before/Divergent.Finance.API/Controllers/PricesController.cs
+++ b/exercises/02-publish-subscribe/before/Divergent.Finance.API/Controllers/PricesController.cs
@@ -1,5 +1,4 @@
 ﻿using Divergent.Finance.Data.Context;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
@@ -12,23 +11,21 @@ namespace Divergent.Finance.API.Controllers
         [HttpGet, Route("orders/total")]
         public IEnumerable<dynamic> GetOrdersTotal(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
             using (var db = new FinanceContext())
             {
-                var query = db.OrderItemPrices
-                    .Where(op => _orderIds.Contains(op.OrderId))
-                    .GroupBy(op => op.OrderId)
-                    .Select(g => new
+                return db.OrderItemPrices
+                    .Where(orderItemPrice => orderIdList.Contains(orderItemPrice.OrderId))
+                    .GroupBy(orderItemPrice => orderItemPrice.OrderId)
+                    .Select(orderGroup => new
                     {
-                        OrderId = g.Key,
-                        Amount = g.Sum(op => op.ItemPrice)
-                    });
-
-                var result = query.ToArray();
-                return result;
+                        OrderId = orderGroup.Key,
+                        Amount = orderGroup.Sum(orderItemPrice => orderItemPrice.ItemPrice),
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/02-publish-subscribe/before/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/02-publish-subscribe/before/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using Divergent.Sales.Data.Context;
+using Divergent.Sales.Messages.Commands;
+using NServiceBus;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Http;
-using Divergent.Sales.Data.Context;
-using NServiceBus;
-using Divergent.Sales.Messages.Commands;
 
 namespace Divergent.Sales.API.Controllers
 {
@@ -14,17 +14,14 @@ namespace Divergent.Sales.API.Controllers
     {
         private readonly IEndpointInstance _endpoint;
 
-        public OrdersController(IEndpointInstance endpoint)
-        {
-            _endpoint = endpoint;
-        }
+        public OrdersController(IEndpointInstance endpoint) => _endpoint = endpoint;
 
         [HttpPost, Route("createOrder")]
         public async Task<dynamic> CreateOrder(dynamic payload)
         {
             var customerId = int.Parse((string)payload.customerId);
             var productIds = ((IEnumerable<dynamic>)payload.products)
-                .Select(p => int.Parse((string)p.productId))
+                .Select(product => int.Parse((string)product.productId))
                 .ToList();
 
             await _endpoint.Send(new SubmitOrderCommand
@@ -39,21 +36,19 @@ namespace Divergent.Sales.API.Controllers
         [HttpGet]
         public IEnumerable<dynamic> Get()
         {
-            using (var _context = new SalesContext())
+            using (var db = new SalesContext())
             {
-                var orders = _context.Orders
-                .Include(i => i.Items)
-                .Include(i => i.Items.Select(x => x.Product))
-                .ToArray();
-
-                return orders
-                    .Select(o => new
+                return db.Orders
+                    .Include(order => order.Items)
+                    .Include(order => order.Items.Select(item => item.Product))
+                    .Select(order => new
                     {
-                        o.Id,
-                        o.CustomerId,
-                        ProductIds = o.Items.Select(i => i.Product.Id),
-                        ItemsCount = o.Items.Count
-                    });
+                        order.Id,
+                        order.CustomerId,
+                        ProductIds = order.Items.Select(item => item.Product.Id).ToList(),
+                        ItemsCount = order.Items.Count
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/03-sagas/after/Divergent.Customers.API/Controllers/CustomersController.cs
+++ b/exercises/03-sagas/after/Divergent.Customers.API/Controllers/CustomersController.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿using Divergent.Customers.Data.Context;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
 using System.Web.Http;
-using Divergent.Customers.Data.Context;
-using System.Data.Entity;
 
 namespace Divergent.Customers.API.Controllers
 {
@@ -13,30 +12,29 @@ namespace Divergent.Customers.API.Controllers
         [HttpGet, Route("byorders")]
         public IEnumerable<dynamic> ByOrders(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
+            List<Data.Models.Customer> customers;
+
             using (var db = new CustomersContext())
             {
-                var query = db.Customers
-                    .Include(c => c.Orders)
-                    .Where(c => c.Orders.Any(o => _orderIds.Contains(o.OrderId)));
-
-                var customers = query.ToList();
-                var orders = customers.SelectMany(c => c.Orders).Where(o => _orderIds.Contains(o.OrderId));
-
-                var results = new List<dynamic>();
-                foreach (var order in orders)
-                {
-                    results.Add(new
-                    {
-                        OrderId = order.OrderId,
-                        CustomerName = customers.Single(c => c.Id == order.CustomerId).Name
-                    });
-                }
-                return results;
+                customers = db.Customers
+                    .Include(customer => customer.Orders)
+                    .Where(customer => customer.Orders.Any(order => orderIdList.Contains(order.OrderId)))
+                    .ToList();
             }
+
+            return customers
+                .SelectMany(customer => customer.Orders)
+                .Where(order => orderIdList.Contains(order.OrderId))
+                .Select(order => new
+                {
+                    order.OrderId,
+                    CustomerName = customers.Single(customer => customer.Id == order.CustomerId).Name,
+                })
+                .ToList();
         }
     }
 }

--- a/exercises/03-sagas/after/Divergent.Finance.API/Controllers/PricesController.cs
+++ b/exercises/03-sagas/after/Divergent.Finance.API/Controllers/PricesController.cs
@@ -1,5 +1,4 @@
 ﻿using Divergent.Finance.Data.Context;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
@@ -12,23 +11,21 @@ namespace Divergent.Finance.API.Controllers
         [HttpGet, Route("orders/total")]
         public IEnumerable<dynamic> GetOrdersTotal(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
             using (var db = new FinanceContext())
             {
-                var query = db.OrderItemPrices
-                    .Where(op => _orderIds.Contains(op.OrderId))
-                    .GroupBy(op => op.OrderId)
-                    .Select(g => new
+                return db.OrderItemPrices
+                    .Where(orderItemPrice => orderIdList.Contains(orderItemPrice.OrderId))
+                    .GroupBy(orderItemPrice => orderItemPrice.OrderId)
+                    .Select(orderGroup => new
                     {
-                        OrderId = g.Key,
-                        Amount = g.Sum(op => op.ItemPrice)
-                    });
-
-                var result = query.ToArray();
-                return result;
+                        OrderId = orderGroup.Key,
+                        Amount = orderGroup.Sum(orderItemPrice => orderItemPrice.ItemPrice),
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/03-sagas/before/Divergent.Customers.API/Controllers/CustomersController.cs
+++ b/exercises/03-sagas/before/Divergent.Customers.API/Controllers/CustomersController.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿using Divergent.Customers.Data.Context;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
 using System.Web.Http;
-using Divergent.Customers.Data.Context;
-using System.Data.Entity;
 
 namespace Divergent.Customers.API.Controllers
 {
@@ -13,30 +12,29 @@ namespace Divergent.Customers.API.Controllers
         [HttpGet, Route("byorders")]
         public IEnumerable<dynamic> ByOrders(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
+            List<Data.Models.Customer> customers;
+
             using (var db = new CustomersContext())
             {
-                var query = db.Customers
-                    .Include(c => c.Orders)
-                    .Where(c => c.Orders.Any(o => _orderIds.Contains(o.OrderId)));
-
-                var customers = query.ToList();
-                var orders = customers.SelectMany(c => c.Orders).Where(o => _orderIds.Contains(o.OrderId));
-
-                var results = new List<dynamic>();
-                foreach (var order in orders)
-                {
-                    results.Add(new
-                    {
-                        OrderId = order.OrderId,
-                        CustomerName = customers.Single(c => c.Id == order.CustomerId).Name
-                    });
-                }
-                return results;
+                customers = db.Customers
+                    .Include(customer => customer.Orders)
+                    .Where(customer => customer.Orders.Any(order => orderIdList.Contains(order.OrderId)))
+                    .ToList();
             }
+
+            return customers
+                .SelectMany(customer => customer.Orders)
+                .Where(order => orderIdList.Contains(order.OrderId))
+                .Select(order => new
+                {
+                    order.OrderId,
+                    CustomerName = customers.Single(customer => customer.Id == order.CustomerId).Name,
+                })
+                .ToList();
         }
     }
 }

--- a/exercises/03-sagas/before/Divergent.Finance.API/Controllers/PricesController.cs
+++ b/exercises/03-sagas/before/Divergent.Finance.API/Controllers/PricesController.cs
@@ -1,5 +1,4 @@
 ﻿using Divergent.Finance.Data.Context;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
@@ -12,23 +11,21 @@ namespace Divergent.Finance.API.Controllers
         [HttpGet, Route("orders/total")]
         public IEnumerable<dynamic> GetOrdersTotal(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
             using (var db = new FinanceContext())
             {
-                var query = db.OrderItemPrices
-                    .Where(op => _orderIds.Contains(op.OrderId))
-                    .GroupBy(op => op.OrderId)
-                    .Select(g => new
+                return db.OrderItemPrices
+                    .Where(orderItemPrice => orderIdList.Contains(orderItemPrice.OrderId))
+                    .GroupBy(orderItemPrice => orderItemPrice.OrderId)
+                    .Select(orderGroup => new
                     {
-                        OrderId = g.Key,
-                        Amount = g.Sum(op => op.ItemPrice)
-                    });
-
-                var result = query.ToArray();
-                return result;
+                        OrderId = orderGroup.Key,
+                        Amount = orderGroup.Sum(orderItemPrice => orderItemPrice.ItemPrice),
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/04-integration/after/Divergent.Finance.API/Controllers/PricesController.cs
+++ b/exercises/04-integration/after/Divergent.Finance.API/Controllers/PricesController.cs
@@ -1,5 +1,4 @@
 ﻿using Divergent.Finance.Data.Context;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
@@ -12,23 +11,21 @@ namespace Divergent.Finance.API.Controllers
         [HttpGet, Route("orders/total")]
         public IEnumerable<dynamic> GetOrdersTotal(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
             using (var db = new FinanceContext())
             {
-                var query = db.OrderItemPrices
-                    .Where(op => _orderIds.Contains(op.OrderId))
-                    .GroupBy(op => op.OrderId)
-                    .Select(g => new
+                return db.OrderItemPrices
+                    .Where(orderItemPrice => orderIdList.Contains(orderItemPrice.OrderId))
+                    .GroupBy(orderItemPrice => orderItemPrice.OrderId)
+                    .Select(orderGroup => new
                     {
-                        OrderId = g.Key,
-                        Amount = g.Sum(op => op.ItemPrice)
-                    });
-
-                var result = query.ToArray();
-                return result;
+                        OrderId = orderGroup.Key,
+                        Amount = orderGroup.Sum(orderItemPrice => orderItemPrice.ItemPrice),
+                    })
+                    .ToList();
             }
         }
     }

--- a/exercises/04-integration/before/Divergent.Finance.API/Controllers/PricesController.cs
+++ b/exercises/04-integration/before/Divergent.Finance.API/Controllers/PricesController.cs
@@ -1,5 +1,4 @@
 ﻿using Divergent.Finance.Data.Context;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
@@ -12,23 +11,21 @@ namespace Divergent.Finance.API.Controllers
         [HttpGet, Route("orders/total")]
         public IEnumerable<dynamic> GetOrdersTotal(string orderIds)
         {
-            var _orderIds = orderIds.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            var orderIdList = orderIds.Split(',')
                 .Select(id => int.Parse(id))
                 .ToList();
 
             using (var db = new FinanceContext())
             {
-                var query = db.OrderItemPrices
-                    .Where(op => _orderIds.Contains(op.OrderId))
-                    .GroupBy(op => op.OrderId)
-                    .Select(g => new
+                return db.OrderItemPrices
+                    .Where(orderItemPrice => orderIdList.Contains(orderItemPrice.OrderId))
+                    .GroupBy(orderItemPrice => orderItemPrice.OrderId)
+                    .Select(orderGroup => new
                     {
-                        OrderId = g.Key,
-                        Amount = g.Sum(op => op.ItemPrice)
-                    });
-
-                var result = query.ToArray();
-                return result;
+                        OrderId = orderGroup.Key,
+                        Amount = orderGroup.Sum(orderItemPrice => orderItemPrice.ItemPrice),
+                    })
+                    .ToList();
             }
         }
     }


### PR DESCRIPTION
- switched usage of `ToArray()` to `ToList()` (less allocation)
- renamed variables with names starting with an underscore
- renamed variables with single char names
- simplified `Split()` call
- minimised EF context scope
- aligned EF context variable naming
- in-lined single use local variables
- converted one line constructors to expressions
- changed list property assignment to eager evaluation