### PR TITLE
align DevelopmentServerPort with IISUrl

### DIFF
--- a/exercises/01-composite-ui/after/Divergent.Customers.API/Divergent.Customers.API.csproj
+++ b/exercises/01-composite-ui/after/Divergent.Customers.API/Divergent.Customers.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20186</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20186/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/01-composite-ui/after/Divergent.Finance.API/Divergent.Finance.API.csproj
+++ b/exercises/01-composite-ui/after/Divergent.Finance.API/Divergent.Finance.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20187</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20187/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/01-composite-ui/before/Divergent.Customers.API/Divergent.Customers.API.csproj
+++ b/exercises/01-composite-ui/before/Divergent.Customers.API/Divergent.Customers.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20186</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20186/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/01-composite-ui/before/Divergent.Finance.API/Divergent.Finance.API.csproj
+++ b/exercises/01-composite-ui/before/Divergent.Finance.API/Divergent.Finance.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20187</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20187/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/02-publish-subscribe/after/Divergent.Customers.API/Divergent.Customers.API.csproj
+++ b/exercises/02-publish-subscribe/after/Divergent.Customers.API/Divergent.Customers.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20186</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20186/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/02-publish-subscribe/after/Divergent.Finance.API/Divergent.Finance.API.csproj
+++ b/exercises/02-publish-subscribe/after/Divergent.Finance.API/Divergent.Finance.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20187</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20187/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/02-publish-subscribe/before/Divergent.Customers.API/Divergent.Customers.API.csproj
+++ b/exercises/02-publish-subscribe/before/Divergent.Customers.API/Divergent.Customers.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20186</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20186/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/02-publish-subscribe/before/Divergent.Finance.API/Divergent.Finance.API.csproj
+++ b/exercises/02-publish-subscribe/before/Divergent.Finance.API/Divergent.Finance.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20187</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20187/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/03-sagas/after/Divergent.Customers.API/Divergent.Customers.API.csproj
+++ b/exercises/03-sagas/after/Divergent.Customers.API/Divergent.Customers.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20186</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20186/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/03-sagas/after/Divergent.Finance.API/Divergent.Finance.API.csproj
+++ b/exercises/03-sagas/after/Divergent.Finance.API/Divergent.Finance.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20187</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20187/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/03-sagas/before/Divergent.Customers.API/Divergent.Customers.API.csproj
+++ b/exercises/03-sagas/before/Divergent.Customers.API/Divergent.Customers.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20186</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20186/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/03-sagas/before/Divergent.Finance.API/Divergent.Finance.API.csproj
+++ b/exercises/03-sagas/before/Divergent.Finance.API/Divergent.Finance.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20187</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20187/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/04-integration/after/Divergent.Customers.API/Divergent.Customers.API.csproj
+++ b/exercises/04-integration/after/Divergent.Customers.API/Divergent.Customers.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20186</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20186/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/04-integration/after/Divergent.Finance.API/Divergent.Finance.API.csproj
+++ b/exercises/04-integration/after/Divergent.Finance.API/Divergent.Finance.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20187</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20187/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/04-integration/before/Divergent.Customers.API/Divergent.Customers.API.csproj
+++ b/exercises/04-integration/before/Divergent.Customers.API/Divergent.Customers.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20186</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20186/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/exercises/04-integration/before/Divergent.Finance.API/Divergent.Finance.API.csproj
+++ b/exercises/04-integration/before/Divergent.Finance.API/Divergent.Finance.API.csproj
@@ -210,7 +210,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>20185</DevelopmentServerPort>
+          <DevelopmentServerPort>20187</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:20187/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>


### PR DESCRIPTION
The ports which are hard coded into the web API client code match the ports in the `IISUrl`. This means that the solutions do not work when `DevelopmentServerPort` is used, since the ports do not match those in `IISUrl`.

This PR updates the `DevelopmentServerPort` ports to match those in `IISUrl`.

On my workstation, for some reason, `DevelopmentServerPort` is used instead of `IISUrl`. I updated that machine to VS 15.6.0 yesterday. Perhaps that has something to do with it.