### PR TITLE
move demos to net core 2.0 runtime

### DIFF
--- a/demos/asp-net-core/Divergent.CompositionGateway/Divergent.CompositionGateway.csproj
+++ b/demos/asp-net-core/Divergent.CompositionGateway/Divergent.CompositionGateway.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Divergent.Sales.ViewModelComposition.Events\Divergent.Sales.ViewModelComposition.Events.csproj" />

--- a/demos/asp-net-core/Divergent.CompositionGateway/Divergent.CompositionGateway.csproj
+++ b/demos/asp-net-core/Divergent.CompositionGateway/Divergent.CompositionGateway.csproj
@@ -8,7 +8,6 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.2" />
   </ItemGroup>

--- a/demos/asp-net-core/Divergent.CompositionGateway/Program.cs
+++ b/demos/asp-net-core/Divergent.CompositionGateway/Program.cs
@@ -12,7 +12,6 @@ namespace Divergent.CompositionGateway
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()
                 .UseStartup<Startup>()
-                .UseApplicationInsights()
                 .Build();
 
             host.Run();

--- a/demos/asp-net-core/Divergent.Sales.ViewModelComposition.Events/Divergent.Sales.ViewModelComposition.Events.csproj
+++ b/demos/asp-net-core/Divergent.Sales.ViewModelComposition.Events/Divergent.Sales.ViewModelComposition.Events.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/demos/asp-net-core/Divergent.Sales.ViewModelComposition/Divergent.Sales.ViewModelComposition.csproj
+++ b/demos/asp-net-core/Divergent.Sales.ViewModelComposition/Divergent.Sales.ViewModelComposition.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/demos/asp-net-core/Divergent.Shipping.ViewModelComposition/Divergent.Shipping.ViewModelComposition.csproj
+++ b/demos/asp-net-core/Divergent.Shipping.ViewModelComposition/Divergent.Shipping.ViewModelComposition.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/demos/asp-net-core/Divergent.Website/Divergent.Website.csproj
+++ b/demos/asp-net-core/Divergent.Website/Divergent.Website.csproj
@@ -8,7 +8,6 @@
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />

--- a/demos/asp-net-core/Divergent.Website/Divergent.Website.csproj
+++ b/demos/asp-net-core/Divergent.Website/Divergent.Website.csproj
@@ -1,20 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="1.1.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.3" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0" />

--- a/demos/asp-net-core/Divergent.Website/Program.cs
+++ b/demos/asp-net-core/Divergent.Website/Program.cs
@@ -12,7 +12,6 @@ namespace Divergent.Website
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()
                 .UseStartup<Startup>()
-                .UseApplicationInsights()
                 .Build();
 
             host.Run();

--- a/demos/asp-net-core/Divergent.Website/Properties/launchSettings.json
+++ b/demos/asp-net-core/Divergent.Website/Properties/launchSettings.json
@@ -1,12 +1,12 @@
-﻿{
-    "profiles": {
-        "Divergent.Website": {
-            "commandName": "Project",
-            "launchBrowser": true,
-            "environmentVariables": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "applicationUrl": "http://localhost:11493"
-        }
+{
+  "profiles": {
+    "Divergent.Website": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:11493"
     }
+  }
 }

--- a/demos/asp-net-core/Divergent.Website/Views/Shared/_Layout.cshtml
+++ b/demos/asp-net-core/Divergent.Website/Views/Shared/_Layout.cshtml
@@ -1,5 +1,4 @@
-﻿@inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -16,7 +15,6 @@
               asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
         <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
     </environment>
-    @Html.Raw(JavaScriptSnippet.FullScript)
 </head>
 <body>
     <nav class="navbar navbar-inverse navbar-fixed-top">

--- a/demos/asp-net-core/ITOps.Json/ITOps.Json.csproj
+++ b/demos/asp-net-core/ITOps.Json/ITOps.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/demos/asp-net-core/ITOps.ViewModelComposition.Gateway/ITOps.ViewModelComposition.Gateway.csproj
+++ b/demos/asp-net-core/ITOps.ViewModelComposition.Gateway/ITOps.ViewModelComposition.Gateway.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demos/asp-net-core/ITOps.ViewModelComposition.Mvc/ITOps.ViewModelComposition.Mvc.csproj
+++ b/demos/asp-net-core/ITOps.ViewModelComposition.Mvc/ITOps.ViewModelComposition.Mvc.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demos/asp-net-core/ITOps.ViewModelComposition/ITOps.ViewModelComposition.csproj
+++ b/demos/asp-net-core/ITOps.ViewModelComposition/ITOps.ViewModelComposition.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/demos/asp-net-core/README.md
+++ b/demos/asp-net-core/README.md
@@ -2,7 +2,7 @@
 
 This demo is composed of two solutions which demonstrate UI Composition techniques using ASP.NET Core.
 
-In order to run the demos, you require the latest .NET Core Runtime in the [1.1.x version range](https://www.microsoft.com/net/download/all).
+In order to run the demos, you require the latest .NET Core Runtime in the [2.0.x version range](https://www.microsoft.com/net/download/all).
 
 ### Divergent.CompositionGateway
 


### PR DESCRIPTION
Moves the demo to NET Core 2.x

Since it was an easy fix I took the liberty of working on it. We should probably merge this after NDC Minnesota to not create any confusion to attendees