### PR TITLE
[WIP] Surface composition exceptions

### DIFF
--- a/exercises/01-composite-ui/after/Divergent.CompositionGateway/Startup.cs
+++ b/exercises/01-composite-ui/after/Divergent.CompositionGateway/Startup.cs
@@ -22,6 +22,7 @@ namespace Divergent.CompositionGateway
                 policyBuilder.AllowAnyOrigin();
                 policyBuilder.AllowAnyMethod();
                 policyBuilder.AllowAnyHeader();
+                policyBuilder.WithExposedHeaders("composition-errors");
             });
 
             app.RunCompositionGatewayWithDefaultRoutes();

--- a/exercises/01-composite-ui/after/Divergent.Frontend/app/presentation/ordersController.js
+++ b/exercises/01-composite-ui/after/Divergent.Frontend/app/presentation/ordersController.js
@@ -11,12 +11,20 @@
 
                 ctrl.refreshOrders = function () {
                     ctrl.isLoading = $http.get(config.gatewayBaseUrl + '/orders/')
-                        .then(function (response) {
+                        .then(function successCallback(response) {
                             ctrl.orders = response.data.orders;
-                        })
-                        .catch(function (error) {
-                            $log.error('Something went wrong: ', error);
-                            ctrl.loadError = 'Something went wrong. Look at the console log in your browser';
+                        }, function errorCallback(response) {
+                            $log.error('Something went wrong: ', response);
+                            var compositionErrors = response.headers('composition-errors');
+                            if (compositionErrors)
+                            {
+                                $log.error('Composition errors: ', $('<textarea/>').html(compositionErrors).text());
+                                ctrl.loadError = 'Something went wrong during the composition process. Look at the console log in your browser.';
+                            }
+                            else
+                            {
+                                ctrl.loadError = 'Something went wrong. Look at the console log in your browser';
+                            }
                         });
                 };
 

--- a/exercises/shared-api-gateway/ITOps.ViewModelComposition/DynamicViewModel.cs
+++ b/exercises/shared-api-gateway/ITOps.ViewModelComposition/DynamicViewModel.cs
@@ -75,7 +75,14 @@ namespace ITOps.ViewModelComposition
                     tasks.Add(handler.Invoke(this, @event, routeData, query));
                 }
 
-                return Task.WhenAll(tasks);
+                return Task.WhenAll(tasks)
+                    .ContinueWith(t=>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            throw t.Exception.Flatten();
+                        }
+                    });
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
When exceptions happen during the composition process they are returned to the client as `HTTP-500` with no other details than `Internal Server Error`.

This is an attempt to surface composition exceptions. It's currently very raw, it's merely an exercise, and serves only as a discussion. The problem we want to solve is: when attendees are doing exercises it's very easy to mess up something or in the composition engine or in the back-end APIs. In this case the UI is not helpful at all since it simply say that something went wrong, without any hint on what went badly.

By using something similar to what is proposed here, the result in the browser console will be:

![image](https://user-images.githubusercontent.com/1325611/39784302-3e7124d6-5318-11e8-9f8f-46ee1ad71b9c.png)

In order to go ahead some async/await-fu is needed, I'm pretty sure there is a better solution to this than the one I applied.