### PR TITLE
[WIP] Add logging to composition engine

### DIFF
--- a/exercises/01-composite-ui/after/Divergent.CompositionGateway/Divergent.CompositionGateway.csproj
+++ b/exercises/01-composite-ui/after/Divergent.CompositionGateway/Divergent.CompositionGateway.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\shared-api-gateway\ITOps.ViewModelComposition.Gateway\ITOps.ViewModelComposition.Gateway.csproj" />

--- a/exercises/01-composite-ui/after/Divergent.CompositionGateway/Startup.cs
+++ b/exercises/01-composite-ui/after/Divergent.CompositionGateway/Startup.cs
@@ -17,6 +17,8 @@ namespace Divergent.CompositionGateway
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
+            loggerFactory.AddConsole(LogLevel.Warning);
+
             app.UseCors(policyBuilder =>
             {
                 policyBuilder.AllowAnyOrigin();


### PR DESCRIPTION
Replaces https://github.com/Particular/Workshop/pull/258

it's a possible implementation to provide logging at the composition engine level, the same logic can be applied to all back-end APIs, so that all errors will surface somewhere