### PR TITLE
switch set-startup-projects.cmd for SwitchStartupProject

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ The exercises are contained in eight Visual Studio solutions under [exercises](e
 
 ## Running the exercise solutions
 
-Before opening any exercise solutions, set the startup projects by navigating to your copy of this repo and running `set-startup-projects.cmd`. Note that if you `git clean` your clone, you will have to run this command again.
+Before running an exercise solution, you need to set the startup projects.
 
-NOTE: do not run `set-startup-projects.cmd` while an exercise or demo solution is open. The script deletes and regenerates user settings for every solution. If it is run while a solution is open, the settings may be corrupted.
+One way to do this is to use the [SwitchStartupProject](https://marketplace.visualstudio.com/items?itemName=vs-publisher-141975.SwitchStartupProjectforVS2017) Visual Studio extension. After installing the extension, open the exercise solution and choose the "Exercise" startup configuration.
 
 The startup projects are also listed in the instructions for each exercise. If you need to, you can configure them manually:
 

--- a/build.csx
+++ b/build.csx
@@ -1,11 +1,8 @@
-#r "packages/SetStartupProjects.1.4.0/lib/net452/SetStartupProjects.dll"
-
 #load "packages/simple-targets-csx.6.0.0/contentFiles/csx/any/simple-targets.csx"
 #load "scripts/cmd.csx"
 
 using System;
 using static SimpleTargets;
-using SetStartupProjects;
 
 var vswhere = "packages/vswhere.2.1.4/tools/vswhere.exe";
 var nuget = ".nuget/v4.3.0/NuGet.exe";
@@ -64,32 +61,5 @@ targets.Add(
         }
     });
 
-targets.Add(
-    "delete-vs-folders",
-    () =>
-    {
-        foreach (var suo in Directory.EnumerateDirectories(".", ".vs", SearchOption.AllDirectories))
-        {
-            Directory.Delete(suo, true);
-        }
-    }
-);
-
-targets.Add(
-    "set-startup-projects",
-    DependsOn("delete-vs-folders"),
-    () =>
-    {
-        var suoCreator = new StartProjectSuoCreator();
-        foreach (var sln in Directory.EnumerateFiles(".", "*.sln", SearchOption.AllDirectories))
-        {
-            var startProjects = new StartProjectFinder().GetStartProjects(sln).ToList();
-            if (startProjects.Any())
-            {
-                suoCreator.CreateForSolutionFile(sln, startProjects, VisualStudioVersions.Vs2017);
-            }
-        }
-    }
-);
 
 Run(Args, targets);

--- a/exercises/01-composite-ui/after/01-composite-ui-after.sln.startup.json
+++ b/exercises/01-composite-ui/after/01-composite-ui-after.sln.startup.json
@@ -1,0 +1,15 @@
+{
+    "Version": 3,
+    "ListAllProjects": true,
+    "MultiProjectConfigurations": {
+        "Exercise": {
+            "Projects": {
+                "Divergent.CompositionGateway": {},
+                "Divergent.Customers.API": {},
+                "Divergent.Finance.API": {},
+                "Divergent.Frontend": {},
+                "Divergent.Sales.API": {}
+            }
+        }
+    }
+}

--- a/exercises/01-composite-ui/before/01-composite-ui-before.sln.startup.json
+++ b/exercises/01-composite-ui/before/01-composite-ui-before.sln.startup.json
@@ -1,0 +1,15 @@
+{
+    "Version": 3,
+    "ListAllProjects": true,
+    "MultiProjectConfigurations": {
+        "Exercise": {
+            "Projects": {
+                "Divergent.CompositionGateway": {},
+                "Divergent.Customers.API": {},
+                "Divergent.Finance.API": {},
+                "Divergent.Frontend": {},
+                "Divergent.Sales.API": {}
+            }
+        }
+    }
+}

--- a/exercises/02-publish-subscribe/after/02-publish-subscribe-after.sln.startup.json
+++ b/exercises/02-publish-subscribe/after/02-publish-subscribe-after.sln.startup.json
@@ -1,0 +1,20 @@
+{
+    "Version": 3,
+    "ListAllProjects": true,
+    "MultiProjectConfigurations": {
+        "Exercise": {
+            "Projects": {
+                "Divergent.CompositionGateway": {},
+                "Divergent.Customers": {},
+                "Divergent.Customers.API": {},
+                "Divergent.Finance": {},
+                "Divergent.Finance.API": {},
+                "Divergent.Frontend": {},
+                "Divergent.Sales": {},
+                "Divergent.Sales.API": {},
+                "Divergent.Shipping": {},
+                "PaymentProviders": {}
+            }
+        }
+    }
+}

--- a/exercises/02-publish-subscribe/before/02-publish-subscribe-before.sln.startup.json
+++ b/exercises/02-publish-subscribe/before/02-publish-subscribe-before.sln.startup.json
@@ -1,0 +1,20 @@
+{
+    "Version": 3,
+    "ListAllProjects": true,
+    "MultiProjectConfigurations": {
+        "Exercise": {
+            "Projects": {
+                "Divergent.CompositionGateway": {},
+                "Divergent.Customers": {},
+                "Divergent.Customers.API": {},
+                "Divergent.Finance": {},
+                "Divergent.Finance.API": {},
+                "Divergent.Frontend": {},
+                "Divergent.Sales": {},
+                "Divergent.Sales.API": {},
+                "Divergent.Shipping": {},
+                "PaymentProviders": {}
+            }
+        }
+    }
+}

--- a/exercises/03-sagas/after/03-sagas-after.sln.startup.json
+++ b/exercises/03-sagas/after/03-sagas-after.sln.startup.json
@@ -1,0 +1,20 @@
+{
+    "Version": 3,
+    "ListAllProjects": true,
+    "MultiProjectConfigurations": {
+        "Exercise": {
+            "Projects": {
+                "Divergent.CompositionGateway": {},
+                "Divergent.Customers": {},
+                "Divergent.Customers.API": {},
+                "Divergent.Finance": {},
+                "Divergent.Finance.API": {},
+                "Divergent.Frontend": {},
+                "Divergent.Sales": {},
+                "Divergent.Sales.API": {},
+                "Divergent.Shipping": {},
+                "PaymentProviders": {}
+            }
+        }
+    }
+}

--- a/exercises/03-sagas/before/03-sagas-before.sln.startup.json
+++ b/exercises/03-sagas/before/03-sagas-before.sln.startup.json
@@ -1,0 +1,20 @@
+{
+    "Version": 3,
+    "ListAllProjects": true,
+    "MultiProjectConfigurations": {
+        "Exercise": {
+            "Projects": {
+                "Divergent.CompositionGateway": {},
+                "Divergent.Customers": {},
+                "Divergent.Customers.API": {},
+                "Divergent.Finance": {},
+                "Divergent.Finance.API": {},
+                "Divergent.Frontend": {},
+                "Divergent.Sales": {},
+                "Divergent.Sales.API": {},
+                "Divergent.Shipping": {},
+                "PaymentProviders": {}
+            }
+        }
+    }
+}

--- a/exercises/04-integration/after/04-integration-after.sln.startup.json
+++ b/exercises/04-integration/after/04-integration-after.sln.startup.json
@@ -1,0 +1,21 @@
+{
+    "Version": 3,
+    "ListAllProjects": true,
+    "MultiProjectConfigurations": {
+        "Exercise": {
+            "Projects": {
+                "Divergent.CompositionGateway": {},
+                "Divergent.Customers": {},
+                "Divergent.Customers.API": {},
+                "Divergent.Finance": {},
+                "Divergent.Finance.API": {},
+                "Divergent.Frontend": {},
+                "Divergent.ITOps": {},
+                "Divergent.Sales": {},
+                "Divergent.Sales.API": {},
+                "Divergent.Shipping": {},
+                "PaymentProviders": {}
+            }
+        }
+    }
+}

--- a/exercises/04-integration/before/04-integration-before.sln.startup.json
+++ b/exercises/04-integration/before/04-integration-before.sln.startup.json
@@ -1,0 +1,21 @@
+{
+    "Version": 3,
+    "ListAllProjects": true,
+    "MultiProjectConfigurations": {
+        "Exercise": {
+            "Projects": {
+                "Divergent.CompositionGateway": {},
+                "Divergent.Customers": {},
+                "Divergent.Customers.API": {},
+                "Divergent.Finance": {},
+                "Divergent.Finance.API": {},
+                "Divergent.Frontend": {},
+                "Divergent.ITOps": {},
+                "Divergent.Sales": {},
+                "Divergent.Sales.API": {},
+                "Divergent.Shipping": {},
+                "PaymentProviders": {}
+            }
+        }
+    }
+}

--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Net.Compilers" version="2.4.0" />
-  <package id="SetStartupProjects" version="1.4.0" />
   <package id="simple-targets-csx" version="6.0.0" />
   <package id="vswhere" version="2.1.4" />
 </packages>

--- a/set-startup-projects.cmd
+++ b/set-startup-projects.cmd
@@ -1,1 +1,0 @@
-build.cmd set-startup-projects


### PR DESCRIPTION
Visual Studio probably changed something in the `.suo` file format and now startup projects set using the `set-startup-projects` scripts are not preserved across Visual Studio restarts. Confirmed also by @DavidBoike that faced the same issue at NCD Minnesota last week.

I needed to find a workaround since as a trainer it happens that I re-open the same exercise multiple times. The easiest workaround is to use the [SwitchStartupProject for 2017](https://marketplace.visualstudio.com/items?itemName=vs-publisher-141975.SwitchStartupProjectforVS2017).

This si a WIP/SPIKE and is meant to be a workaround till we find a better solution, if any. I pushed and opened this just to raise awareness. And to have a backup 😄 