### PR TITLE
SqlLite and Entity Framework int64 issue

### DIFF
--- a/demos/asp-net-core/Divergent.Shipping.API.Host/Controllers/ShipmentsController.cs
+++ b/demos/asp-net-core/Divergent.Shipping.API.Host/Controllers/ShipmentsController.cs
@@ -20,6 +20,7 @@ namespace Divergent.Shipping.API.Host.Controllers
             {
                 var shipment = await db.Shipments
                     .Where(s => s.OrderNumber == orderNumber)
+                    .Select(s => new { s.OrderNumber, s.Courier, s.Status })
                     .SingleOrDefaultAsync();
 
                 return new


### PR DESCRIPTION
On the plane I tested the Composition Gateway demo and shipping had an issue where it could not retrieve data and crashed. I got an error saying `Expecting Int32 but I got an Int64 for Id column`, or the other way around.

I fixed it by adding a projection to exclude the `Id` column since we didn't use it anywhere, we only need the primary key for querying.

There might be a proper solution, but for now I just wanted to submit this so that if it fails for others, they are aware of this solution.