### PR TITLE
switch to Bullseye

### DIFF
--- a/build.csx
+++ b/build.csx
@@ -1,8 +1,8 @@
-#load "packages/simple-targets-csx.6.0.0/contentFiles/csx/any/simple-targets.csx"
+#r "packages/Bullseye.1.0.0-rc.5/lib/netstandard2.0/Bullseye.dll"
 #load "scripts/cmd.csx"
 
 using System;
-using static SimpleTargets;
+using static Bullseye.Targets;
 
 var vswhere = "packages/vswhere.2.1.4/tools/vswhere.exe";
 var nuget = ".nuget/v4.3.0/NuGet.exe";
@@ -11,11 +11,9 @@ string msBuild = null;
 var demoSolutions = Directory.EnumerateFiles("demos", "*.sln", SearchOption.AllDirectories);
 var exerciseSolutions = Directory.EnumerateFiles("exercises", "*.sln", SearchOption.AllDirectories);
 
-var targets = new TargetDictionary();
+Add("default", DependsOn("demos", "exercises"));
 
-targets.Add("default", DependsOn("demos", "exercises"));
-
-targets.Add(
+Add(
     "restore-demos",
     () =>
     {
@@ -25,7 +23,7 @@ targets.Add(
         }
     });
 
-targets.Add(
+Add(
     "restore-exercises",
     () =>
     {
@@ -35,11 +33,11 @@ targets.Add(
         }
     });
 
-targets.Add(
+Add(
     "find-msbuild",
     () => msBuild = $"{ReadCmd(vswhere, "-latest -requires Microsoft.Component.MSBuild -property installationPath").Trim()}/MSBuild/15.0/Bin/MSBuild.exe");
 
-targets.Add(
+Add(
     "demos",
     DependsOn("find-msbuild", "restore-demos"),
     () =>
@@ -50,7 +48,7 @@ targets.Add(
         }
     });
 
-targets.Add(
+Add(
     "exercises",
     DependsOn("find-msbuild", "restore-exercises"),
     () =>
@@ -62,4 +60,4 @@ targets.Add(
     });
 
 
-Run(Args, targets);
+Run(Args);

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Net.Compilers" version="2.4.0" />
-  <package id="simple-targets-csx" version="6.0.0" />
+  <package id="Bullseye" version="1.0.0-rc.5" />
   <package id="vswhere" version="2.1.4" />
 </packages>


### PR DESCRIPTION
[Bullseye](https://github.com/adamralph/bullseye) replaces simple-targets-csx (it's a regular binary package instead of scripts, so can optionally be used in a [regular .NET project](https://github.com/xbehave/xbehave.net/blob/6d798877b4b891ce95ea8f2c5f9bee3d56a26bae/targets/Program.cs#L8)).