### PR TITLE
switch to dotnet build

### DIFF
--- a/build.csx
+++ b/build.csx
@@ -4,40 +4,16 @@
 using System;
 using static Bullseye.Targets;
 
-var vswhere = "packages/vswhere.2.1.4/tools/vswhere.exe";
-var nuget = ".nuget/v4.3.0/NuGet.exe";
-string msBuild = null;
-
-var demoSolutions = Directory.EnumerateFiles("demos", "*.sln", SearchOption.AllDirectories);
-var exerciseSolutions = Directory.EnumerateFiles("exercises", "*.sln", SearchOption.AllDirectories);
-
 Target("default", DependsOn("demos", "exercises"));
 
 Target(
-    "restore-demos",
-    demoSolutions,
-    solution => Cmd(nuget, $"restore {solution}"));
-
-Target(
-    "restore-exercises",
-    exerciseSolutions,
-    solution => Cmd(nuget, $"restore {solution}"));
-
-Target(
-    "find-msbuild",
-    () => msBuild = $"{ReadCmd(vswhere, "-latest -requires Microsoft.Component.MSBuild -property installationPath").Trim()}/MSBuild/15.0/Bin/MSBuild.exe");
-
-Target(
     "demos",
-    DependsOn("find-msbuild", "restore-demos"),
-    demoSolutions,
-    solution => Cmd(msBuild, $"{solution} /p:Configuration=Debug /nologo /m /v:m /nr:false"));
+    Directory.EnumerateFiles("demos", "*.sln", SearchOption.AllDirectories),
+    solution => Cmd("dotnet", $"build {solution} --configuration Debug"));
 
 Target(
     "exercises",
-    DependsOn("find-msbuild", "restore-exercises"),
-    exerciseSolutions,
-    solution => Cmd(msBuild, $"{solution} /p:Configuration=Debug /nologo /m /v:m /nr:false"));
-
+    Directory.EnumerateFiles("exercises", "*.sln", SearchOption.AllDirectories),
+    solution => Cmd("dotnet", $"build {solution} --configuration Debug"));
 
 RunTargets(Args);

--- a/packages.config
+++ b/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="Microsoft.Net.Compilers" version="2.4.0" />
   <package id="Bullseye" version="1.1.0-rc.2" />
-  <package id="vswhere" version="2.1.4" />
 </packages>


### PR DESCRIPTION
Now that we're on the new csproj everywhere, we can just use `dotnet build`.