### PR TITLE
[wip] [spike] Minimize HTTP API console windows

### DIFF
--- a/exercises/04-integration/after/Divergent.Customers.API/ConsoleEx.cs
+++ b/exercises/04-integration/after/Divergent.Customers.API/ConsoleEx.cs
@@ -1,0 +1,15 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Divergent.Customers.API
+{
+    static class ConsoleEx
+    {
+        public static void TryMinimize()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                WindowsNativeMethods.ShowWindow(WindowsNativeMethods.GetConsoleWindow(), WindowsNativeMethods.SW_SHOWMINIMIZED);
+            }
+        }
+    }
+}

--- a/exercises/04-integration/after/Divergent.Customers.API/Divergent.Customers.API.csproj
+++ b/exercises/04-integration/after/Divergent.Customers.API/Divergent.Customers.API.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/exercises/04-integration/after/Divergent.Customers.API/Program.cs
+++ b/exercises/04-integration/after/Divergent.Customers.API/Program.cs
@@ -10,6 +10,7 @@ namespace Divergent.Customers.API
         public static async Task Main(string[] args)
         {
             Console.Title = MethodBase.GetCurrentMethod().DeclaringType.Namespace;
+            ConsoleEx.TryMinimize();
 
             var tcs = new TaskCompletionSource<object>();
             Console.CancelKeyPress += (sender, e) => { tcs.SetResult(null); };

--- a/exercises/04-integration/after/Divergent.Customers.API/WindowsNativeMethods.cs
+++ b/exercises/04-integration/after/Divergent.Customers.API/WindowsNativeMethods.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Divergent.Customers.API
+{
+    static class WindowsNativeMethods
+    {
+        public const int SW_SHOWMINIMIZED = 2;
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr GetConsoleWindow();
+
+        [DllImport("user32.dll")]
+        public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+    }
+}


### PR DESCRIPTION
Connects to #295.

This will do it.  Note that it needs `net471` or higher, or a switch to any version of `netcoreapp`: https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation#applies-to

If we like it, we need to think about how to get this code into all the API projects. I'm reluctant to duplicate it.